### PR TITLE
refactor(ui): use local state to store right dataset column names

### DIFF
--- a/src/components/stepforms/JoinStepForm.vue
+++ b/src/components/stepforms/JoinStepForm.vue
@@ -129,7 +129,7 @@ export default class JoinStepForm extends BaseStepForm<JoinStep> {
     });
   }
 
-  rightColumnNames?: string[];
+  rightColumnNames: string[] | null | undefined = null;
 
   @VQBModule.Action getColumnNamesFromPipeline!: (
     pipelineNameOrDomain: string,
@@ -137,6 +137,12 @@ export default class JoinStepForm extends BaseStepForm<JoinStep> {
 
   async updateRightColumnNames(pipelineNameOrDomain: string) {
     this.rightColumnNames = await this.getColumnNamesFromPipeline(pipelineNameOrDomain);
+  }
+
+  created() {
+    if (this.rightPipeline.label) {
+      this.updateRightColumnNames(this.rightPipeline.label);
+    }
   }
 }
 </script>

--- a/src/components/stepforms/JoinStepForm.vue
+++ b/src/components/stepforms/JoinStepForm.vue
@@ -11,7 +11,7 @@
       v-model="rightPipeline"
       name="Select a dataset to join (as right dataset):"
       :options="options"
-      :change="selectRightColumnNames({ rightPipelineLabel: rightPipeline.label })"
+      @input="updateRightColumnNames(rightPipeline.label)"
       placeholder="Select a dataset"
       data-path=".right_pipeline"
       :errors="errors"
@@ -35,7 +35,7 @@
       v-model="on"
       :defaultItem="['', '']"
       :widget="joinColumns"
-      :componentProps="{ syncWithSelectedColumn: false }"
+      :componentProps="{ syncWithSelectedColumn: false, rightColumnNames }"
       :automatic-new-field="false"
       data-path=".on"
       :errors="errors"
@@ -88,12 +88,6 @@ export default class JoinStepForm extends BaseStepForm<JoinStep> {
   @VQBModule.Getter referencingPipelines!: string[];
   @VQBModule.Getter availableDatasetNames!: string[];
 
-  @VQBModule.Action selectRightColumnNames!: ({
-    rightPipelineLabel,
-  }: {
-    rightPipelineLabel: string;
-  }) => void;
-
   readonly title: string = 'Join datasets';
   joinColumns = JoinColumns;
   joinTypes: JoinStep['type'][] = joinTypes;
@@ -133,6 +127,16 @@ export default class JoinStepForm extends BaseStepForm<JoinStep> {
       }
       return option;
     });
+  }
+
+  rightColumnNames?: string[];
+
+  @VQBModule.Action getColumnNamesFromPipeline!: (
+    pipelineNameOrDomain: string,
+  ) => Promise<string[] | undefined>;
+
+  async updateRightColumnNames(pipelineNameOrDomain: string) {
+    this.rightColumnNames = await this.getColumnNamesFromPipeline(pipelineNameOrDomain);
   }
 }
 </script>

--- a/src/components/stepforms/widgets/JoinColumns.vue
+++ b/src/components/stepforms/widgets/JoinColumns.vue
@@ -75,7 +75,7 @@ export default class JoinColumns extends Vue {
   @VQBModule.Getter columnNames!: string[];
 
   @Prop()
-  rightColumnNames?: string[];
+  rightColumnNames?: string[] | null; // because initializing to undefined won't make it reactive
 
   get leftOnColumn() {
     return this.value[0];

--- a/src/components/stepforms/widgets/JoinColumns.vue
+++ b/src/components/stepforms/widgets/JoinColumns.vue
@@ -10,12 +10,25 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
     />
+    <!-- defaults to a simple text input if we don't have any column names -->
     <AutocompleteWidget
+      v-if="rightColumnNames"
       class="rightOn"
       data-cy="weaverbird-join-column-right-on"
       v-model="rightOnColumn"
       placeholder="Right dataset column"
       :options="rightColumnNames"
+      :data-path="`${dataPath}[1]`"
+      :errors="errors"
+      :available-variables="availableVariables"
+      :variable-delimiters="variableDelimiters"
+    />
+    <InputTextWidget
+      v-else
+      class="rightOn"
+      data-cy="weaverbird-join-column-right-on"
+      v-model="rightOnColumn"
+      placeholder="Right dataset column"
       :data-path="`${dataPath}[1]`"
       :errors="errors"
       :available-variables="availableVariables"
@@ -61,7 +74,8 @@ export default class JoinColumns extends Vue {
 
   @VQBModule.Getter columnNames!: string[];
 
-  @VQBModule.Getter rightColumnNames!: string[];
+  @Prop()
+  rightColumnNames?: string[];
 
   get leftOnColumn() {
     return this.value[0];

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -106,35 +106,32 @@ class Actions {
     dispatch('updateDataset');
   }
 
-  async selectRightColumnNames(
-    { commit, state }: ActionContext<VQBState, any>,
-    { rightPipelineLabel }: { rightPipelineLabel: string },
-  ) {
-    if (rightPipelineLabel != '') {
-      let activePipeline: Pipeline = [];
+  // Retrieve the first row from a pipeline, so we can infer its columns names
+  async getColumnNamesFromPipeline(
+    { state }: ActionContext<VQBState, any>,
+    pipelineNameOrDomain: string,
+  ): Promise<string[] | undefined> {
+    if (!pipelineNameOrDomain) {
+      return;
+    }
 
-      if (rightPipelineLabel in state.pipelines) {
-        activePipeline = state.pipelines[rightPipelineLabel];
-      } else {
-        activePipeline = [
-          {
-            name: 'domain',
-            domain: rightPipelineLabel,
-          },
-        ];
-      }
+    let pipeline: Pipeline = [];
 
-      const response = await state.backendService.executePipeline(
-        activePipeline,
-        state.pipelines,
-        1,
-        0,
-      );
-      if (response.data) {
-        commit('setRightColumnNames', {
-          rightColumnNames: response.data.headers.map(col => col.name),
-        });
-      }
+    if (pipelineNameOrDomain in state.pipelines) {
+      pipeline = state.pipelines[pipelineNameOrDomain];
+    } else {
+      pipeline = [
+        {
+          name: 'domain',
+          domain: pipelineNameOrDomain,
+        },
+      ];
+    }
+
+    const response = await state.backendService.executePipeline(pipeline, state.pipelines, 1, 0);
+
+    if (response.data) {
+      return response.data.headers.map(col => col.name);
     }
   }
 

--- a/tests/unit/join-columns.spec.ts
+++ b/tests/unit/join-columns.spec.ts
@@ -21,11 +21,13 @@ describe('Widget JoinColumnsWidget', () => {
 
   it('should have exactly 2 input components', () => {
     const wrapper = shallowMount(JoinColumns, { store: emptyStore, localVue });
-    const autocompleteWrappers = wrapper.findAll('autocompletewidget-stub');
-    expect(autocompleteWrappers.length).toEqual(2);
+    const rightComponentWrappers = wrapper.findAll('.rightOn');
+    const leftComponentWrappers = wrapper.findAll('.leftOn');
+    expect(rightComponentWrappers.length).toEqual(1);
+    expect(leftComponentWrappers.length).toEqual(1);
   });
 
-  it('should instantiate a widgetAutocomplete widget with proper options from the store', () => {
+  it('should suggest the columns of the actual dataset in the left widget', () => {
     const store = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
@@ -33,11 +35,11 @@ describe('Widget JoinColumnsWidget', () => {
       },
     });
     const wrapper = shallowMount(JoinColumns, { store, localVue });
-    const autocompleteWrapper = wrapper.find('autocompletewidget-stub');
-    expect(autocompleteWrapper.attributes('options')).toEqual('columnA,columnB,columnC');
+    const leftWidgetWrapper = wrapper.find('.leftOn');
+    expect(leftWidgetWrapper.props().options).toEqual(['columnA', 'columnB', 'columnC']);
   });
 
-  it('should pass down the right prop to the left AutocompleteWidget', () => {
+  it('should pass down the value to the left widget', () => {
     const wrapper = shallowMount(JoinColumns, {
       propsData: {
         value: ['toto', 'tata'],
@@ -46,11 +48,11 @@ describe('Widget JoinColumnsWidget', () => {
       localVue,
       sync: false,
     });
-    const autocompleteWrapper = wrapper.find('autocompletewidget-stub');
-    expect(autocompleteWrapper.props().value).toEqual('toto');
+    const leftWidgetWrapper = wrapper.find('.leftOn');
+    expect(leftWidgetWrapper.props().value).toEqual('toto');
   });
 
-  it('should pass down the right prop to the right AutocompleteWidget', () => {
+  it('should pass down the value to the right widget', () => {
     const wrapper = shallowMount(JoinColumns, {
       propsData: {
         value: ['toto', 'tata'],
@@ -59,8 +61,32 @@ describe('Widget JoinColumnsWidget', () => {
       localVue,
       sync: false,
     });
-    const autocompleteWrapper = wrapper.findAll('autocompletewidget-stub').at(1);
-    expect(autocompleteWrapper.props().value).toEqual('tata');
+    const rightWidgetWrapper = wrapper.find('.rightOn');
+    expect(rightWidgetWrapper.props().value).toEqual('tata');
+  });
+
+  it('should pass down the columns names of the right dataset in an autocomplete if provided', () => {
+    const wrapper = shallowMount(JoinColumns, {
+      propsData: {
+        rightColumnNames: ['meow', 'plop'],
+      },
+      store: emptyStore,
+      localVue,
+      sync: false,
+    });
+    const rightWidgetWrapper = wrapper.find('.rightOn');
+    expect(rightWidgetWrapper.is('AutocompleteWidget-stub')).toBe(true);
+    expect(rightWidgetWrapper.props().options).toEqual(['meow', 'plop']);
+  });
+
+  it('should let user freely input if right dataset column names are not provided', () => {
+    const wrapper = shallowMount(JoinColumns, {
+      store: emptyStore,
+      localVue,
+      sync: false,
+    });
+    const rightWidgetWrapper = wrapper.find('.rightOn');
+    expect(rightWidgetWrapper.is('InputTextWidget-stub')).toBe(true);
   });
 
   it('should update its value when the left column is modified', () => {
@@ -73,8 +99,8 @@ describe('Widget JoinColumnsWidget', () => {
       sync: false,
     });
 
-    const autocompleteWrapper = wrapper.find('autocompletewidget-stub');
-    autocompleteWrapper.vm.$emit('input', 'tutu');
+    const leftWidgetWrapper = wrapper.find('.leftOn');
+    leftWidgetWrapper.vm.$emit('input', 'tutu');
 
     expect(wrapper.emitted().input).toBeDefined();
     expect(wrapper.emitted().input[0]).toEqual([['tutu', 'tata']]);
@@ -90,8 +116,8 @@ describe('Widget JoinColumnsWidget', () => {
       sync: false,
     });
 
-    const autocompleteWrapper = wrapper.findAll('autocompletewidget-stub').at(1);
-    autocompleteWrapper.vm.$emit('input', 'tutu');
+    const rightWidgetWrapper = wrapper.find('.rightOn');
+    rightWidgetWrapper.vm.$emit('input', 'tutu');
 
     expect(wrapper.emitted().input).toBeDefined();
     expect(wrapper.emitted().input[0]).toEqual([['toto', 'tutu']]);
@@ -107,8 +133,8 @@ describe('Widget JoinColumnsWidget', () => {
       sync: false,
     });
 
-    const autocompleteWrapper = wrapper.find('autocompletewidget-stub');
-    autocompleteWrapper.vm.$emit('input', 'tutu');
+    const leftWidgetWrapper = wrapper.find('.leftOn');
+    leftWidgetWrapper.vm.$emit('input', 'tutu');
 
     expect(wrapper.emitted().input).toBeDefined();
     expect(wrapper.emitted().input[0]).toEqual([['tutu', 'tutu']]);

--- a/tests/unit/join-step-form.spec.ts
+++ b/tests/unit/join-step-form.spec.ts
@@ -15,7 +15,7 @@ describe('join Step Form', () => {
   runner.testCancel();
   runner.testResetSelectedIndex();
 
-  describe('AutocompleteWidget', () => {
+  describe('right dataset', () => {
     it('should instantiate an autocomplete widget with proper options from the store', () => {
       const initialState = {
         currentPipelineName: 'my_dataset',
@@ -43,7 +43,7 @@ describe('join Step Form', () => {
     });
   });
 
-  describe('ListWidget', () => {
+  describe('column names', () => {
     it('should pass down the "joinColumns" prop to the ListWidget value prop', async () => {
       const wrapper = runner.shallowMount(undefined, {
         data: {

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -1,3 +1,5 @@
+import { Store } from 'vuex';
+
 import { BackendService } from '@/lib/backend';
 import { DataSet } from '@/lib/dataset';
 import { Pipeline } from '@/lib/steps';
@@ -7,7 +9,7 @@ import getters from '@/store/getters';
 import mutations from '@/store/mutations';
 import { currentPipeline, emptyState } from '@/store/state';
 
-import { buildState, buildStateWithOnePipeline, setupMockStore } from './utils';
+import { buildState, buildStateWithOnePipeline, RootState, setupMockStore } from './utils';
 
 describe('getter tests', () => {
   describe('pipelines', () => {
@@ -701,56 +703,6 @@ describe('mutation tests', () => {
     expect(state.dataset).toEqual(dataset);
   });
 
-  it('sets right column names', () => {
-    buildState({
-      currentPipelineName: 'coco_l_asticot',
-      pipelines: {
-        coco_l_asticot: [],
-        dataset1: [],
-        dataset2: [],
-      },
-    });
-
-    const store = setupMockStore();
-    const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-    store.dispatch(VQBnamespace('selectRightColumnNames'), { rightPipelineLabel: '' });
-    expect(dispatchSpy).not.toHaveBeenLastCalledWith(VQBnamespace('executePipeline'), '');
-
-    store.dispatch(VQBnamespace('selectRightColumnNames'), {
-      rightPipelineLabel: 'coco_l_asticot',
-    });
-    expect(dispatchSpy).not.toHaveBeenLastCalledWith(
-      VQBnamespace('executePipeline'),
-      [],
-      {
-        coco_l_asticot: [],
-        dataset1: [],
-        dataset2: [],
-      },
-      1,
-      0,
-    );
-
-    store.dispatch(VQBnamespace('selectRightColumnNames'), { rightPipelineLabel: 'other' });
-    expect(dispatchSpy).not.toHaveBeenLastCalledWith(
-      VQBnamespace('executePipeline'),
-      [
-        {
-          name: 'domain',
-          domain: 'other',
-        },
-      ],
-      {
-        coco_l_asticot: [],
-        dataset1: [],
-        dataset2: [],
-      },
-      1,
-      0,
-    );
-  });
-
   it('should create a step form', () => {
     const state = buildState({});
     mutations.createStepForm(state, { stepName: 'filter' });
@@ -1217,6 +1169,90 @@ describe('action tests', () => {
         index: 1,
         message: 'Step specific error',
       });
+    });
+  });
+
+  describe('getColumnNamesFromPipeline', () => {
+    let store: Store<RootState>, mockBackendServiceExecutePipeline: jest.Mock;
+
+    beforeEach(() => {
+      mockBackendServiceExecutePipeline = jest.fn();
+
+      store = setupMockStore(
+        buildState({
+          backendService: {
+            executePipeline: mockBackendServiceExecutePipeline,
+            listCollections: jest.fn(),
+          },
+          currentPipelineName: 'coco_l_asticot',
+          pipelines: {
+            coco_l_asticot: [
+              { name: 'domain', domain: 'plop' },
+              { name: 'text', new_column: 'yolo', text: 'asticot' },
+            ],
+            dataset1: [],
+            dataset2: [],
+          },
+        }),
+      );
+    });
+
+    it('should not return anything if no pipeline name or domain is provided', async () => {
+      expect(await store.dispatch(VQBnamespace('getColumnNamesFromPipeline'))).toBeUndefined();
+      expect(mockBackendServiceExecutePipeline).not.toHaveBeenCalled();
+    });
+
+    it('should return the column names from an existing pipeline', async () => {
+      mockBackendServiceExecutePipeline.mockResolvedValue({
+        data: { headers: [{ name: 'A' }, { name: 'B' }, { name: 'C' }] },
+      });
+      expect(
+        await store.dispatch(VQBnamespace('getColumnNamesFromPipeline'), 'coco_l_asticot'),
+      ).toEqual(['A', 'B', 'C']);
+      expect(mockBackendServiceExecutePipeline).toHaveBeenLastCalledWith(
+        [
+          { name: 'domain', domain: 'plop' },
+          { name: 'text', new_column: 'yolo', text: 'asticot' },
+        ],
+        {
+          coco_l_asticot: [
+            { name: 'domain', domain: 'plop' },
+            { name: 'text', new_column: 'yolo', text: 'asticot' },
+          ],
+          dataset1: [],
+          dataset2: [],
+        },
+        1,
+        0,
+      );
+    });
+
+    it('should return the column names from a domain', async () => {
+      mockBackendServiceExecutePipeline.mockResolvedValue({
+        data: { headers: [{ name: 'meow' }, { name: 'ouaf' }] },
+      });
+      expect(await store.dispatch(VQBnamespace('getColumnNamesFromPipeline'), 'other')).toEqual([
+        'meow',
+        'ouaf',
+      ]);
+      expect(mockBackendServiceExecutePipeline).toHaveBeenLastCalledWith(
+        [
+          {
+            name: 'domain',
+            domain: 'other',
+          },
+        ],
+        {
+          coco_l_asticot: [
+            { name: 'domain', domain: 'plop' },
+            { name: 'text', new_column: 'yolo', text: 'asticot' },
+          ],
+          dataset1: [],
+          dataset2: [],
+        },
+        1,
+        0,
+      );
     });
   });
 });


### PR DESCRIPTION
Hi @CharlesRngrd!
I've had a bit of time this week to make these commits, showing how we can avoid storing the right column names  into the store and using just a prop instead (as discussed in https://github.com/ToucanToco/weaverbird/pull/1008)
I've also took the opportunity to handle the case where we can't fetch the columns, and rework a bit the test cases.

What do you think?
Cheers! (and happy new year :) )