### PR TITLE
fix(cumsum): types with legacy/new syntax, metadata for snowflake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 - NewDateInput: send analytics event when selecting a relative date
 
+## Unreleased
+
+## Added
+
+- Cumsum step: can handle multiple columns at once (by @CharlesRngrd)
+
 ## [0.77.0] - 2021-12-06
 
 ### Added

--- a/docs/_docs/user-interface/cumsum.md
+++ b/docs/_docs/user-interface/cumsum.md
@@ -25,8 +25,9 @@ of the computation. The computation can be scoped by group if needed.
 
 <img src="../../img/docs/user-interface/cumsum_step_form.jpg" width="350" />
 
-- `Value column to sum`: the value column you want to compute the cumulated sum
-  of.
+- `Columns to cumulate`: the value columns you want to compute the cumulated sum
+  of, and for each one the name of the result column (by default it will be your
+  original column  name suffixed by '\_CUMSUM')
 
 - `Reference column to sort (usually dates)`: the column that will be used to
   order rows in ascending order. Usually you will use a date column here
@@ -35,10 +36,6 @@ of the computation. The computation can be scoped by group if needed.
 - `(Optional) Group cumulated sum by`: optional, if you need to apply the
   cumulated sum computation by group of rows, you may specify here the columns
   to be used to constitute groups (see example 2 below)
-
-- `(Optional) New column name`: Optional, if you want to give a custom name to
-  the output column to be created (by default it will be your original columnn
-  name suffixed by '\_CUMSUM').
 
 #### Example 1 : Basic configuration
 

--- a/server/src/weaverbird/backends/sql_translator/steps/cumsum.py
+++ b/server/src/weaverbird/backends/sql_translator/steps/cumsum.py
@@ -46,9 +46,6 @@ def translate_cumsum(
         # if any new column name had been provided
         new_column = cumsum[1] or f"{cumsum[0]}_CUMSUM"
 
-        # we make sure to add the new column in the metadata list
-        query.metadata_manager.add_query_metadata_column(new_column, "FLOAT")
-
         new_columns.append(new_column)
 
         cumsum_part += f", SUM({cumsum[0]}) OVER (PARTITION BY {partition_by_sub_query}"
@@ -67,6 +64,10 @@ def translate_cumsum(
         f"SELECT {completed_fields}{cumsum_part}"
         f" FROM {query.query_name} ORDER BY {step.reference_column} ASC"
     )
+
+    # we make sure to add the new columns in the metadata list
+    for new_column in new_columns:
+        query.metadata_manager.add_query_metadata_column(new_column, "FLOAT")
 
     new_query = SQLQuery(
         query_name=query_name,

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -151,12 +151,18 @@ export type ConvertStep = {
 
 export type CumSumStep = {
   name: 'cumsum';
-  valueColumn?: string; // supported for retrocompatibility only
   referenceColumn: string;
   groupby?: string[];
-  newColumn?: string; // supported for retrocompatibility only
-  toCumSum: string[][];
-};
+} & (
+  | {
+      toCumSum: string[][];
+    }
+  | {
+      // legacy way to declare columns (one only)
+      valueColumn: string;
+      newColumn?: string;
+    }
+);
 
 export type CustomStep = {
   name: 'custom';

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -155,7 +155,7 @@ export type CumSumStep = {
   groupby?: string[];
 } & (
   | {
-      toCumSum: string[][];
+      toCumSum: [string, string][];
     }
   | {
       // legacy way to declare columns (one only)

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -208,17 +208,26 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
   }
 
   cumsum(step: Readonly<S.CumSumStep>) {
-    return {
+    const interpolatedPartialStep = {
       ...step,
-      // For retrocompatibility purposes
-      valueColumn: _interpolate(this.interpolateFunc, step.valueColumn, this.context),
       referenceColumn: _interpolate(this.interpolateFunc, step.referenceColumn, this.context),
       groupby: (step.groupby ?? []).map(col =>
         _interpolate(this.interpolateFunc, col, this.context),
       ),
-      // For retrocompatibility purposes
-      newColumn: _interpolate(this.interpolateFunc, step.newColumn, this.context),
-      toCumSum: step.toCumSum.map(([valueColumn, newColumn]) => [
+    };
+
+    // Legacy syntax
+    if ('valueColumn' in step) {
+      return {
+        ...interpolatedPartialStep,
+        valueColumn: _interpolate(this.interpolateFunc, step.valueColumn, this.context),
+        newColumn: _interpolate(this.interpolateFunc, step.newColumn, this.context),
+      };
+    }
+
+    return {
+      ...interpolatedPartialStep,
+      toCumSum: step.toCumSum.map(([valueColumn, newColumn]): [string, string] => [
         _interpolate(this.interpolateFunc, valueColumn, this.context),
         _interpolate(this.interpolateFunc, newColumn, this.context),
       ]),

--- a/tests/unit/labeller.spec.ts
+++ b/tests/unit/labeller.spec.ts
@@ -665,7 +665,7 @@ describe('Labeller', () => {
     expect(hrl(step)).toEqual('Roll-up hierarchy ["city", "country", "continent"]');
   });
 
-  it('generates label for cumsum steps old-fashioned', () => {
+  it('generates label for cumsum steps with legacy value/newColumn properties', () => {
     // Test for retrocompatibility purposes
     const step: S.CumSumStep = {
       name: 'cumsum',
@@ -673,7 +673,6 @@ describe('Labeller', () => {
       referenceColumn: 'DATE',
       groupby: ['COUNTRY', 'PRODUCT'],
       newColumn: 'MY_NEW_COLUMN',
-      toCumSum: [[]],
     };
     expect(hrl(step)).toEqual('Compute cumulated sum of "VALUE"');
   });

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -4039,11 +4039,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
     ]);
   });
 
-  it('can generate basic old fashion cumsum steps if needed', () => {
+  it('can translate legacy cumsum steps (with valueColum property)', () => {
     const pipeline: Pipeline = [
       {
         name: 'cumsum',
-        toCumSum: [],
         valueColumn: 'VALUE',
         referenceColumn: 'DATE',
       },
@@ -4070,11 +4069,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
     ]);
   });
 
-  it('can generate more complex old fashion cumsum steps if needed', () => {
+  it('can translate legacy cumsum steps (with valueColum property) with newColumn and groupby', () => {
     const pipeline: Pipeline = [
       {
         name: 'cumsum',
-        toCumSum: [],
         valueColumn: 'VALUE',
         referenceColumn: 'DATE',
         groupby: ['COUNTRY', 'PRODUCT'],
@@ -4108,7 +4106,7 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
     ]);
   });
 
-  it('can generate basic new fashion cumsum steps if needed', () => {
+  it('can translate cumsum steps with multiple columns, renamed or not', () => {
     const pipeline: Pipeline = [
       {
         name: 'cumsum',
@@ -4143,7 +4141,7 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
     ]);
   });
 
-  it('can generate more complex new fashion cumsum steps if needed', () => {
+  it('can translate cumsum steps with groupby', () => {
     const pipeline: Pipeline = [
       {
         name: 'cumsum',

--- a/tests/unit/templating.spec.ts
+++ b/tests/unit/templating.spec.ts
@@ -1382,7 +1382,7 @@ describe('Pipeline interpolator', () => {
     ]);
   });
 
-  it('should interpolate cumsum steps old-fashioned if needed', () => {
+  it('should interpolate legacy cumsum steps (with valueColumn)', () => {
     // Test for retrocompatibility purposes
     const pipeline: Pipeline = [
       {
@@ -1391,7 +1391,6 @@ describe('Pipeline interpolator', () => {
         referenceColumn: '<%= foo %>',
         groupby: ['<%= foo %>'],
         newColumn: '<%= foo %>',
-        toCumSum: [[]],
       },
     ];
     expect(translate(pipeline)).toEqual([
@@ -1401,7 +1400,6 @@ describe('Pipeline interpolator', () => {
         referenceColumn: 'bar',
         groupby: ['bar'],
         newColumn: 'bar',
-        toCumSum: [[undefined, undefined]],
       },
     ]);
   });
@@ -1421,8 +1419,6 @@ describe('Pipeline interpolator', () => {
         referenceColumn: 'bar',
         groupby: ['bar'],
         toCumSum: [['bar', 'bar']],
-        valueColumn: undefined,
-        newColumn: undefined,
       },
     ]);
   });


### PR DESCRIPTION
Here are a few commit to make https://github.com/ToucanToco/weaverbird/pull/999 mergeable.
Notably, I reworked how the type CumSumStep works so there is no need to have an empty toCumSum property in the old syntax (that would break all existing pipelines, making them invalid).